### PR TITLE
Updated Dockerfile to support tzdata request and avoid Java offline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ USER root
 RUN apt-get update
 RUN apt-get -y upgrade
 RUN apt-get install -y curl 
+# The following ENV and ln is to provide automated answer to Location and Timezone to tzdata, while installing apache2
+ENV TZ=Asia/Kolkata
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get install -y apache2
 
 # Make a known working directory for downloads
@@ -17,13 +20,7 @@ RUN mkdir /usr/local/downloadtemp
 ########################################
 # Install Java
 ########################################
-COPY jdk-9.0.4_linux-x64_bin.tar.gz /usr/local/downloadtemp/jdk-9.0.4.tar.gz
-RUN tar xvzf /usr/local/downloadtemp/jdk-9.0.4.tar.gz -C /usr/local
-RUN rm /usr/local/downloadtemp/jdk-9.0.4.tar.gz
-
-# Set Java environment variablees
-ENV JAVA_HOME /usr/local/jdk-9.0.4
-ENV PATH ${PATH}:${JAVA_HOME}/bin
+RUN apt-get install -y openjdk-11-jdk
 
 ########################################
 # Install and Configure Tomcat 


### PR DESCRIPTION
@AdamPaternostro , Thanks for the code. I have tried you code and found it doesn't works currently. Hence I have made few changes as below:
1. It was expecting location and timezone at tzdata of apache2. Hence added support for the same.
2. downloading and uploading of java offline package is not working due to the big size. hence edited those lines to accept openjdk-11.

Expecting you to merge this request.